### PR TITLE
Repository Transfer: Update References to che-incubator

### DIFF
--- a/Formula/kubectx-manager.rb
+++ b/Formula/kubectx-manager.rb
@@ -1,0 +1,48 @@
+class KubectxManager < Formula
+  desc "Advanced Kubernetes context management tool"
+  homepage "https://github.com/che-incubator/kubectx-manager"
+  url "https://github.com/che-incubator/kubectx-manager.git", :tag => "v0.0.1"
+  sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"  # Update when publishing
+  version "0.0.1"
+  head "https://github.com/che-incubator/kubectx-manager.git", :branch => "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  def caveats
+    <<~EOS
+      kubectx-manager has been installed!
+
+      Configuration:
+      Create a ~/.kubectx-manager_ignore file with context patterns to keep (whitelist).
+      The file supports glob patterns (* and ?) for flexible matching.
+
+      Usage examples:
+        kubectx-manager --dry-run          # Preview what would be removed
+        kubectx-manager --auth-check       # Remove contexts with invalid auth
+        kubectx-manager --verbose          # Enable debug output
+        kubectx-manager --quiet            # Suppress all output except errors
+        kubectx-manager restore            # Restore from backup interactively
+
+      Configuration file example (~/.kubectx-manager_ignore):
+        production-*
+        staging-important
+        my-dev-context
+        *-permanent
+
+      The tool will:
+      - Create automatic backups before making changes
+      - Remove orphaned clusters and users
+      - Run without prompts by default (use --interactive for confirmation)
+      - Support both pattern matching and auth status filtering
+      - Allow easy restoration from any backup
+    EOS
+  end
+
+  test do
+    system "#{bin}/kubectx-manager", "--help"
+  end
+end

--- a/cmd/backup_cleanup_test.go
+++ b/cmd/backup_cleanup_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akurinnoy/kubectx-manager/internal/kubeconfig"
-	"github.com/akurinnoy/kubectx-manager/internal/logger"
+	"github.com/che-incubator/kubectx-manager/internal/kubeconfig"
+	"github.com/che-incubator/kubectx-manager/internal/logger"
 )
 
 func TestBackupCleanupAfterRestore(t *testing.T) {

--- a/cmd/merge_aware_test.go
+++ b/cmd/merge_aware_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/akurinnoy/kubectx-manager/internal/kubeconfig"
-	"github.com/akurinnoy/kubectx-manager/internal/logger"
+	"github.com/che-incubator/kubectx-manager/internal/kubeconfig"
+	"github.com/che-incubator/kubectx-manager/internal/logger"
 )
 
 func TestAnalyzeRestoreConflicts(t *testing.T) {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/akurinnoy/kubectx-manager/internal/kubeconfig"
-	"github.com/akurinnoy/kubectx-manager/internal/logger"
+	"github.com/che-incubator/kubectx-manager/internal/kubeconfig"
+	"github.com/che-incubator/kubectx-manager/internal/logger"
 )
 
 const (

--- a/cmd/restore_comprehensive_test.go
+++ b/cmd/restore_comprehensive_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/akurinnoy/kubectx-manager/internal/kubeconfig"
+	"github.com/che-incubator/kubectx-manager/internal/kubeconfig"
 )
 
 // TestRestoreCleanupLogic tests the actual cleanup logic from runRestore function

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/akurinnoy/kubectx-manager/internal/config"
-	"github.com/akurinnoy/kubectx-manager/internal/kubeconfig"
-	"github.com/akurinnoy/kubectx-manager/internal/logger"
+	"github.com/che-incubator/kubectx-manager/internal/config"
+	"github.com/che-incubator/kubectx-manager/internal/kubeconfig"
+	"github.com/che-incubator/kubectx-manager/internal/logger"
 )
 
 // Version information, set by build flags

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/akurinnoy/kubectx-manager
+module github.com/che-incubator/kubectx-manager
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/akurinnoy/kubectx-manager/cmd"
+	"github.com/che-incubator/kubectx-manager/cmd"
 )
 
 func main() {


### PR DESCRIPTION
# Update repository references after transfer to che-incubator

Updates all repository references from `akurinnoy/kubectx-manager` to `che-incubator/kubectx-manager`.

## Changes
- Update go.mod module path and all internal imports
- Add Homebrew formula with correct repository URLs
- All builds and tests pass successfully

## Files Changed
- `go.mod` + 6 Go files: Updated import paths
- `Formula/kubectx-manager.rb`: New Homebrew formula

Ready to merge - no functional changes, just repository references.