### PR TITLE
legal: add Eclipse Public License 2.0 headers to all Go files

### DIFF
--- a/cmd/backup_cleanup_test.go
+++ b/cmd/backup_cleanup_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/merge_aware_test.go
+++ b/cmd/merge_aware_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,5 +1,17 @@
 // Package cmd provides command line interface commands for kubectx-manager.
 // It includes commands for restoring kubernetes contexts from backup files.
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/restore_comprehensive_test.go
+++ b/cmd/restore_comprehensive_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package cmd
 
 import (

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,5 +1,17 @@
 // Package main provides integration tests for kubectx-manager.
 // These tests verify the complete functionality of the CLI tool in real-world scenarios.
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package main
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,17 @@
 // Package config provides configuration management for kubectx-manager.
 // It handles reading and writing configuration files and ignore patterns.
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package config
 
 import (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package config
 
 import (

--- a/internal/kubeconfig/enhanced_auth_test.go
+++ b/internal/kubeconfig/enhanced_auth_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package kubeconfig
 
 import (

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -1,5 +1,17 @@
 // Package kubeconfig provides utilities for managing Kubernetes configuration files.
 // It includes functions for loading, parsing, merging, and backing up kubeconfig files.
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package kubeconfig
 
 import (

--- a/internal/kubeconfig/kubeconfig_test.go
+++ b/internal/kubeconfig/kubeconfig_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package kubeconfig
 
 import (

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,5 +1,17 @@
 // Package logger provides structured logging utilities for kubectx-manager.
 // It supports different log levels and colored output for better readability.
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package logger
 
 import (

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package logger
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
 package main
 
 import (


### PR DESCRIPTION
Added EPL-2.0 license headers with Red Hat copyright to all Go files.